### PR TITLE
configurator: Fix permission issue for com.palm.filecache

### DIFF
--- a/files/sysbus/com.palm.configurator.role.json.in
+++ b/files/sysbus/com.palm.configurator.role.json.in
@@ -5,7 +5,7 @@
     "permissions": [
         {
             "service":"com.palm.configurator",
-            "outbound":["com.palm.activitymanager", "com.palm.db", "com.palm.tempdb", "com.webos.mediadb", "com.webos.epgdb"]
+            "outbound":["com.palm.activitymanager", "com.palm.db", "com.palm.filecache", "com.palm.tempdb", "com.webos.mediadb", "com.webos.epgdb"]
         }
     ]
 }


### PR DESCRIPTION
Fixes: May 01 10:41:30 qemux86-64 ls-hubd[182]: [] [pmlog] ls-hubd LSHUB_NO_OUT_PERMS {"DEST_APP_ID":"com.palm.filecache","SRC_APP_ID":"com.palm.configurator","EXE":"/usr/sbin/configurator","PID":464} "com.palm.configurator" does not have sufficient outbound permissions to communicate with "com.palm.filecache" (cmdline: /usr/sbin/configurator -c {"log":{"appender":{"type":"syslog"},"levels":{"configurator":"notice"}}} service)

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>