### PR TITLE
Add system group to permissions for configurator

### DIFF
--- a/files/sysbus/com.webos.service.configurator.perm.json
+++ b/files/sysbus/com.webos.service.configurator.perm.json
@@ -6,6 +6,7 @@
         "settings",
         "devices",
         "networking.query",
-        "applications.query"
+        "applications.query",
+        "system"
     ]
 }


### PR DESCRIPTION
Filecache call to com.palm.filecache/DefineType can only be done by system as per https://github.com/webOS-ports/filecache/blob/webOS-ports/webOS-OSE/files/sysbus/com.palm.filecache.api.json#L5.

When not allowing system, we'll get:

2019-06-16T17:24:47.122943Z [6] user.warning filecache [] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"com.palm.configurator","CATEGORY":"/","METHOD":"DefineType"} Service security groups don't allow method call.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>